### PR TITLE
fix: use modernc DSN pragma syntax so WAL/busy_timeout actually apply

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -42,10 +42,19 @@ func NewSQLiteStore(dataDir string) (*SQLiteStore, error) {
 
 	dbPath := filepath.Join(dataDir, "clauder.db")
 	debugLog("[NewSQLiteStore] Opening database: %s", dbPath)
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	// NOTE: modernc.org/sqlite uses the _pragma=name(value) DSN syntax, NOT the
+	// mattn/go-sqlite3 _journal_mode=/_busy_timeout= form (which it silently
+	// ignores, leaving journal_mode=delete and busy_timeout=0 -> immediate
+	// "database is locked" errors under concurrent access).
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+	// SQLite allows only a single writer. WAL permits concurrent readers, but
+	// serializing connections eliminates the write-write contention that
+	// busy_timeout alone can deadlock on (two pooled conns upgrading read->write).
+	db.SetMaxOpenConns(1)
 	debugLog("[NewSQLiteStore] Database opened successfully")
 
 	store := &SQLiteStore{db: db, dataDir: dataDir}


### PR DESCRIPTION
## Problem

Users hit recurring **"DB is locked"** errors (surfaced via the message watcher).

The SQLite store was opened with a DSN written for the `mattn/go-sqlite3` driver:

```go
sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
```

But this project uses **`modernc.org/sqlite`** (pure-Go driver), which uses a *different* DSN syntax and **silently ignores** those parameters. Verified empirically against `modernc.org/sqlite v1.44.0`:

```
dsn="...?_journal_mode=WAL&_busy_timeout=5000"                 -> journal_mode=delete busy_timeout=0
dsn="...?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)" -> journal_mode=wal    busy_timeout=5000
```

So in production the DB ran in rollback-journal (`delete`) mode with `busy_timeout=0`. With no busy timeout, the moment the `messageWatcher` polls (`GetInstancesByDirectory` / `GetMessages`) while an MCP write is in flight, SQLite returns `SQLITE_BUSY` *immediately* instead of waiting → "DB is locked".

## Fix

```go
dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
db, err := sql.Open("sqlite", dsn)
...
db.SetMaxOpenConns(1)
```

- Correct **modernc `_pragma=name(value)` syntax** so WAL and the 5s busy-timeout actually apply — readers no longer block the writer, and contended writes wait/retry instead of erroring.
- **`SetMaxOpenConns(1)`** serializes the pool, eliminating the write-write deadlock that `busy_timeout` alone can't resolve (two pooled conns upgrading read→write).

## Notes

- WAL mode is set on the DB file the first time the new binary opens it, so it takes effect after rebuild/reinstall and reconnect.
- No foreign-key constraints exist in the schema, so no behavior change there.

## Testing

- `go build ./...` passes
- `go test ./...` — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)