### PR TITLE
chore(ci): bump checkout/setup-go to v6 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
             suffix: windows-amd64.exe
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23'
 


### PR DESCRIPTION
## Why

The v0.14.0 release build logged a deprecation warning: `actions/checkout@v4` and `actions/setup-go@v5` run on **Node 20**, which GitHub:

- forces onto Node 24 starting **2026-06-16**, and
- removes from runners on **2026-09-16**.

The build still succeeds today, but this clears the warning before it can break a future release.

## Change

- `actions/checkout@v4` → `@v6`
- `actions/setup-go@v5` → `@v6`

Both latest majors run on Node 24 natively (verified against the actions' latest releases: checkout `v6.0.3`, setup-go `v6.4.0`).

## Notes

This only affects the release workflow, which runs on `release: published` / `workflow_dispatch` — so it'll be exercised on the next release rather than on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)