### PR TITLE
fix: stop wrap watcher logs from flooding the terminal

### DIFF
--- a/cmd/wrap.go
+++ b/cmd/wrap.go
@@ -4,10 +4,12 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"sync"
 	"syscall"
@@ -148,21 +150,22 @@ type messageWatcher struct {
 	idleTime     time.Duration
 	cooldown     time.Duration
 	lastInjected time.Time
-	injectMu     sync.Mutex // serializes PTY injections to prevent interleaving
+	injectMu     sync.Mutex    // serializes PTY injections to prevent interleaving
 	tgBot        *telegram.Bot // when set, notify user via Telegram about unread messages
 
 	// Pending injection queue: when CanInject=false, we queue the notification
 	// and retry on subsequent ticks until the PTY is idle.
-	pendingPrompt string   // the prompt to inject once idle
-	pendingNames  []string // instance names with unread messages (for dedup)
-	pendingTgSent bool     // whether we already sent the Telegram notification for this pending batch
+	pendingPrompt    string   // the prompt to inject once idle
+	pendingNames     []string // instance names with unread messages (for dedup)
+	pendingTgSent    bool     // whether we already sent the Telegram notification for this pending batch
+	cantInjectLogged bool     // whether we already logged "CanInject=false" for this pending batch
 
 	// In-flight guard: after injecting, we wait for Claude to process the
 	// message (mark it read) before checking again. This prevents the watcher
 	// from spinning on CanInject=false while Claude is busy responding to
 	// the injection we just sent.
-	inFlight      bool      // true after injection, cleared when unread count drops to 0
-	inFlightSince time.Time // when the injection was sent (safety timeout)
+	inFlight      bool          // true after injection, cleared when unread count drops to 0
+	inFlightSince time.Time     // when the injection was sent (safety timeout)
 	inFlightMax   time.Duration // max time to wait before giving up on in-flight guard
 }
 
@@ -266,6 +269,7 @@ func (w *messageWatcher) checkAndInject() {
 		w.pendingPrompt = ""
 		w.pendingNames = nil
 		w.pendingTgSent = false
+		w.cantInjectLogged = false
 		w.inFlight = false
 		return
 	}
@@ -303,6 +307,7 @@ func (w *messageWatcher) checkAndInject() {
 
 		w.pendingPrompt = prompt
 		w.pendingNames = unreadFor
+		w.cantInjectLogged = false // new batch: allow one retry log again
 
 		// Send Telegram notification when we first detect unread messages
 		if w.tgBot != nil && !w.pendingTgSent {
@@ -324,12 +329,16 @@ func (w *messageWatcher) checkAndInject() {
 		w.pendingPrompt = ""
 		w.pendingNames = nil
 		w.pendingTgSent = false
+		w.cantInjectLogged = false
 		return
 	}
 
-	// Can't inject now — will retry on next tick
-	if w.pendingPrompt != "" {
+	// Can't inject now — will retry on next tick. Log only once per pending
+	// batch; otherwise this spins every tick while the user has typed-but-unsent
+	// input (a non-empty buffer keeps CanInject false indefinitely).
+	if w.pendingPrompt != "" && !w.cantInjectLogged {
 		log.Printf("[watcher] %d unread but CanInject=false, will retry", len(unreadFor))
+		w.cantInjectLogged = true
 	}
 }
 
@@ -465,6 +474,20 @@ func runWrap(cmd *cobra.Command, args []string) error {
 
 	// Open the store for message monitoring
 	dataDir := getDataDir()
+
+	// Redirect the standard logger to a file. In wrap mode stderr is the live
+	// terminal that Claude Code's TUI draws on, so any log.Printf (notably the
+	// message watcher's "CanInject=false, will retry" diagnostics) would
+	// scribble over the screen — the well-known "screen full of can't-inject
+	// errors" symptom. Send it to a log file, or discard it if that fails,
+	// rather than ever writing to the terminal.
+	if lf, err := os.OpenFile(filepath.Join(dataDir, "wrap.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+		log.SetOutput(lf)
+		defer func() { _ = lf.Close() }()
+	} else {
+		log.SetOutput(io.Discard)
+	}
+
 	s, err := store.NewSQLiteStore(dataDir)
 	if err != nil {
 		return fmt.Errorf("failed to open store: %w", err)


### PR DESCRIPTION
## Problem

A well-known bug: while `clauder wrap` is running and the user has typed into the Claude prompt but not yet sent it, the screen fills with `[watcher] N unread but CanInject=false, will retry` errors.

### Root cause

The message watcher logs via the standard `log` package, whose default output is **stderr**. In `wrap` mode stderr is the live terminal that Claude Code's TUI is drawing on — so every `log.Printf` scribbles directly over the screen.

The flood is triggered because `CanInject` stays false whenever the input buffer is non-empty:

```go
func (t *inputTracker) CanInject(idleTimeout time.Duration) bool {
    return len(t.buffer) == 0 && time.Since(t.lastKeystroke) > idleTimeout
}
```

The buffer only clears on Enter / Ctrl+U / Ctrl+C. So if the user types text but doesn't press Enter ("didn't send a message"), `CanInject` is false indefinitely, and the watcher logs the retry line **every tick** (every 5s) onto the TUI.

## Fix

1. **Redirect the standard logger to a file** (`$dataDir/wrap.log`, or `io.Discard` if it can't be opened) before starting the watcher, so no watcher/diagnostic output ever reaches the terminal.
2. **Throttle the retry log** to once per pending batch (reset when the batch changes, clears, or is injected) instead of every tick.

Fix #1 alone resolves the visible symptom; #2 keeps the log file clean and avoids the underlying spin-logging.

## Testing

- `go build ./...`, `go vet ./cmd/`, `go test ./cmd/` all pass.
- `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)